### PR TITLE
Use version metadata to download binary

### DIFF
--- a/Formula/endorctl.rb
+++ b/Formula/endorctl.rb
@@ -1,68 +1,54 @@
 require 'net/http'
 
+class EndorDownloadStrategy < CurlDownloadStrategy
+  def url
+    versioned_url = $download_url
+    versioned_url
+  end
+end
+
 class Endorctl < Formula
 
   homepage "https://github.com/endorlabs/homebrew-tap"
   desc "Endor Labs Homebrew Tap"
-
-  url "https://api.endorlabs.com/meta/version"
   version "latest"
 
+  # Get latest version metadata
+  version_uri = URI("https://api.endorlabs.com/meta/version")
+  http = Net::HTTP.new(version_uri.host, version_uri.port)
+  http.use_ssl = true
+
+  req = Net::HTTP::Get.new(version_uri)
+  res = http.request(req)
+  if res.is_a?(Net::HTTPSuccess)
+    json_data = JSON.parse(res.body)
+    version = json_data["Service"]["Version"]
+    puts "Latest version: #{version}"
+  else
+    ohai "Failed to get version metadata"
+    exit 1
+  end
+
+  # Assume MacOS, ARM
+  use_arch = "arm64"
+  $download_sha = json_data["ClientChecksums"]["ARCH_TYPE_MACOS_ARM64"]
+
+  on_macos do
+    on_intel do
+      use_arch = "amd64"
+      $download_sha = json_data["ClientChecksums"]["ARCH_TYPE_MACOS_AMD64"]
+    end
+  end
+
+  $endorctl_file = "endorctl_#{version}_macos_#{use_arch}"
+  $download_url = "https://api.endorlabs.com/download/endorlabs/#{version}/binaries/#{$endorctl_file}"
+
+  # Download and install
+  url "https://api.endorlabs.com/meta/version", :using => EndorDownloadStrategy
+  sha256 $download_sha
+
   def install
-
-    # Version URI
-    version_uri = URI("https://api.endorlabs.com/meta/version")
-
-    http = Net::HTTP.new(version_uri.host, version_uri.port)
-    http.use_ssl = true
-
-    req = Net::HTTP::Get.new(version_uri)
-    res = http.request(req)
-    if res.is_a?(Net::HTTPSuccess)
-      json_data = JSON.parse(res.body)
-      version = json_data["Service"]["Version"]
-      puts "Latest version: #{version}"
-    else
-      ohai "Failed to get version metadata"
-      exit 1
-    end
-
-    # Assume MacOS, ARM
-    use_arch = "arm64"
-    sha_value = json_data["ClientChecksums"]["ARCH_TYPE_MACOS_ARM64"]
-
-    on_macos do
-      on_intel do
-        use_arch = "amd64"
-        sha_value = json_data["ClientChecksums"]["ARCH_TYPE_MACOS_AMD64"]
-      end
-    end
-
-    # Download URI
-    endorctl_file = "endorctl_#{version}_macos_#{use_arch}"
-    download_uri = URI("https://api.endorlabs.com/download/endorlabs/#{version}/binaries/#{endorctl_file}")
-
-    http = Net::HTTP.new(download_uri.host, download_uri.port)
-    http.use_ssl = true
-
-    req = Net::HTTP::Get.new(download_uri)
-    res = http.request(req)
-    if res.is_a?(Net::HTTPSuccess)
-      File.open("#{endorctl_file}", "wb") do |file|
-        file.write(res.body)
-      end
-    else
-      ohai "Failed to download binary"
-      exit 1
-    end
-    sha256_value = `shasum -a 256 #{endorctl_file}`.split.first
-
-    if sha256_value != sha_value
-      ohai "Checksum mismatch: expected #{sha256_value}, got #{sha_value}"
-      exit 1
-    else
-      bin.install "#{endorctl_file}" => "endorctl"
-    end
+     bin.install "#{$endorctl_file}" => "endorctl"
   end
 
   test do

--- a/Formula/endorctl.rb
+++ b/Formula/endorctl.rb
@@ -1,37 +1,79 @@
+require 'net/http'
+
 class Endorctl < Formula
 
-  desc "Endor Labs CLI"
-
   homepage "https://github.com/endorlabs/homebrew-tap"
+  desc "Endor Labs Homebrew Tap"
 
-  version "v1.5.260"
-
-  on_macos do
-    on_arm do
-      url "https://api.staging.endorlabs.com/download/endorlabs/#{version}/binaries/endorctl_#{version}_macos_arm64"
-      sha256 "c169052a595e5b4e0c6eabaa719371da19b3e7e1d6fb18a9b771f8d4e8a9a8bf"
-    end
-    on_intel do
-      url "https://api.staging.endorlabs.com/download/endorlabs/#{version}/binaries/endorctl_#{version}_macos_amd64"
-      sha256 "0ef1ff4152cdede028017cda087b226c174631eaa966400f95aa66a924d1f50c"
-    end
-  end
-
-
-  #license "MIT"
+  url "https://api.endorlabs.com/meta/version"
+  version "latest"
 
   def install
+    version_uri = URI("https://api.endorlabs.com/meta/version")
+
+    # Create an HTTP object and enable SSL for HTTPS
+    http = Net::HTTP.new(version_uri.host, version_uri.port)
+    http.use_ssl = (version_uri.scheme == "https")
+
+    # Create an HTTP GET request
+    req = Net::HTTP::Get.new(version_uri)
+
+    # Send the GET request and store the response
+    res = http.request(req)
+    if res.is_a?(Net::HTTPSuccess)
+      json_data = JSON.parse(res.body)
+      version = json_data["Service"]["Version"]
+      puts "Latest version: #{version}"
+    else
+      ohai "Failed to get version metadata"
+      exit 1
+    end
+
+    # Assume MacOS, ARM
+    use_arch = "arm64"
+    sha_value = json_data["ClientChecksums"]["ARCH_TYPE_MACOS_ARM64"]
+
     on_macos do
-      on_arm do
-        bin.install "endorctl_#{version}_macos_arm64" => "endorctl"
-      end
       on_intel do
-        bin.install "endorctl_#{version}_macos_amd64" => "endorctl"
+        use_arch = "amd64"
+        sha_value = json_data["ClientChecksums"]["ARCH_TYPE_MACOS_AMD64"]
       end
+    end
+
+    # Download URI
+    endorctl_file = "endorctl_#{version}_macos_#{use_arch}"
+    download_uri = URI("https://api.endorlabs.com/download/endorlabs/#{version}/binaries/#{endorctl_file}")
+
+    # Create an HTTP object and enable SSL for HTTPS
+    http = Net::HTTP.new(download_uri.host, download_uri.port)
+    http.use_ssl = (download_uri.scheme == "https")
+
+    # Create an HTTP GET request
+    req = Net::HTTP::Get.new(download_uri)
+
+    # Send the GET request and store the response
+    res = http.request(req)
+    if res.is_a?(Net::HTTPSuccess)
+      # Save the downloaded file to your download directory
+      File.open("#{endorctl_file}", "wb") do |file|
+        file.write(res.body)
+      end
+    else
+      ohai "Failed to download binary"
+      exit 1
+    end
+    sha256_value = `shasum -a 256 #{endorctl_file}`.split.first
+
+    if sha256_value != sha_value
+      ohai "SHA mismatch: expected #{sha256_value}, got #{sha_value}"
+      exit 1
+    else
+      bin.install "#{endorctl_file}" => "endorctl"
     end
   end
 
   test do
     system "#{bin}/endorctl", "--version"
   end
+
 end

--- a/Formula/endorctl.rb
+++ b/Formula/endorctl.rb
@@ -9,16 +9,14 @@ class Endorctl < Formula
   version "latest"
 
   def install
+
+    # Version URI
     version_uri = URI("https://api.endorlabs.com/meta/version")
 
-    # Create an HTTP object and enable SSL for HTTPS
     http = Net::HTTP.new(version_uri.host, version_uri.port)
-    http.use_ssl = (version_uri.scheme == "https")
+    http.use_ssl = true
 
-    # Create an HTTP GET request
     req = Net::HTTP::Get.new(version_uri)
-
-    # Send the GET request and store the response
     res = http.request(req)
     if res.is_a?(Net::HTTPSuccess)
       json_data = JSON.parse(res.body)
@@ -44,17 +42,12 @@ class Endorctl < Formula
     endorctl_file = "endorctl_#{version}_macos_#{use_arch}"
     download_uri = URI("https://api.endorlabs.com/download/endorlabs/#{version}/binaries/#{endorctl_file}")
 
-    # Create an HTTP object and enable SSL for HTTPS
     http = Net::HTTP.new(download_uri.host, download_uri.port)
-    http.use_ssl = (download_uri.scheme == "https")
+    http.use_ssl = true
 
-    # Create an HTTP GET request
     req = Net::HTTP::Get.new(download_uri)
-
-    # Send the GET request and store the response
     res = http.request(req)
     if res.is_a?(Net::HTTPSuccess)
-      # Save the downloaded file to your download directory
       File.open("#{endorctl_file}", "wb") do |file|
         file.write(res.body)
       end
@@ -65,7 +58,7 @@ class Endorctl < Formula
     sha256_value = `shasum -a 256 #{endorctl_file}`.split.first
 
     if sha256_value != sha_value
-      ohai "SHA mismatch: expected #{sha256_value}, got #{sha_value}"
+      ohai "Checksum mismatch: expected #{sha256_value}, got #{sha_value}"
       exit 1
     else
       bin.install "#{endorctl_file}" => "endorctl"


### PR DESCRIPTION
```
$  brew install -v --build-from-source ~/ws/github/homebrew-tap/Formula/endorctl.rb 
==> Downloading https://formulae.brew.sh/api/formula.jws.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Error: Failed to load cask: /Users/diamantis/ws/github/homebrew-tap/Formula/endorctl.rb
Cask 'endorctl' is unreadable: wrong constant name #<Class:0x00000001170827b8>
Warning: Treating /Users/diamantis/ws/github/homebrew-tap/Formula/endorctl.rb as a formula.
==> Fetching endorctl
==> Downloading https://api.endorlabs.com/meta/version
Already downloaded: /Users/diamantis/Library/Caches/Homebrew/downloads/adf635a718d9170a6cf6cc1ba8f91845bccaf21eb938f396321544de8232dc4f--version
==> Verifying checksum for 'adf635a718d9170a6cf6cc1ba8f91845bccaf21eb938f396321544de8232dc4f--version'
Warning: Cannot verify integrity of 'adf635a718d9170a6cf6cc1ba8f91845bccaf21eb938f396321544de8232dc4f--version'.
No checksum was provided.
For your reference, the checksum is:
  sha256 "808bec5492d7b66de58422eb8e99be7b43c67c2e2b7e8a933c015d1e2ede09ad"
cp -p /Users/diamantis/Library/Caches/Homebrew/downloads/adf635a718d9170a6cf6cc1ba8f91845bccaf21eb938f396321544de8232dc4f--version /private/tmp/endorctl-20231010-41960-1hqc1ls/version
Latest version: v1.5.251
==> Cleaning
==> Finishing up
==> Downloading https://formulae.brew.sh/api/cask.jws.json
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
ln -s ../Cellar/endorctl/latest/bin/endorctl endorctl
==> Summary
🍺  /opt/homebrew/Cellar/endorctl/latest: 3 files, 146.6MB, built in 7 seconds
==> Running `brew cleanup endorctl`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Diamantiss-MacBook-Pro:diamantis:us-central [ (main)] $ which endorctl
/opt/homebrew/bin/endorctl
Diamantiss-MacBook-Pro:diamantis:us-central [ (main)] $ endorctl --version
endorctl version v1.5.251
```