### PR TITLE
Remote extra (debug) output from the endorctl formula

### DIFF
--- a/Formula/endorctl.rb
+++ b/Formula/endorctl.rb
@@ -23,7 +23,6 @@ class Endorctl < Formula
   if res.is_a?(Net::HTTPSuccess)
     json_data = JSON.parse(res.body)
     version = json_data["Service"]["Version"]
-    puts "Latest version: #{version}"
   else
     ohai "Failed to get version metadata"
     exit 1


### PR DESCRIPTION
This PR removes a `puts` (debug?) statement from the `endorctl` formula because it is triggered in some operations that are not related to endorctl specifically. Example:

```
❯ brew cleanup --prune=all
Latest version: v1.6.77
❯
```