### PR TITLE
[BUG-654] Support brew upgrade endorctl

### DIFF
--- a/Formula/endorctl.rb
+++ b/Formula/endorctl.rb
@@ -1,51 +1,55 @@
 require 'net/http'
 
-class EndorDownloadStrategy < CurlDownloadStrategy
-  def url
-    versioned_url = $download_url
-    versioned_url
-  end
-end
-
 class Endorctl < Formula
-
   homepage "https://github.com/endorlabs/homebrew-tap"
   desc "Endor Labs Homebrew Tap"
-  version "latest"
 
-  # Get latest version metadata
-  version_uri = URI("https://api.endorlabs.com/meta/version")
-  http = Net::HTTP.new(version_uri.host, version_uri.port)
-  http.use_ssl = true
+  ENDORCTL_VERSION_URL = "https://api.endorlabs.com/meta/version"
 
-  req = Net::HTTP::Get.new(version_uri)
-  res = http.request(req)
-  if res.is_a?(Net::HTTPSuccess)
-    json_data = JSON.parse(res.body)
-    version = json_data["Service"]["Version"]
-  else
-    ohai "Failed to get version metadata"
-    exit 1
+  # Version check logic
+  livecheck do
+    url ENDORCTL_VERSION_URL
+    strategy :json do |json|
+      json["Service"]["Version"]
+    end
   end
+
+  def self.fetch_version_json
+    uri = URI(ENDORCTL_VERSION_URL)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    req = Net::HTTP::Get.new(uri)
+    res = http.request(req)
+    if res.is_a?(Net::HTTPSuccess)
+      version_json = JSON.parse(res.body)
+      version_json
+    else
+      odie "Failed to get version metadata"
+    end
+  end
+
+  version_json = fetch_version_json
+  version version_json["Service"]["Version"]
 
   # Assume MacOS, ARM
   use_arch = "arm64"
-  $download_sha = json_data["ClientChecksums"]["ARCH_TYPE_MACOS_ARM64"]
+  $download_sha = version_json["ClientChecksums"]["ARCH_TYPE_MACOS_ARM64"]
 
   on_macos do
     on_intel do
       use_arch = "amd64"
-      $download_sha = json_data["ClientChecksums"]["ARCH_TYPE_MACOS_AMD64"]
+      $download_sha = version_json["ClientChecksums"]["ARCH_TYPE_MACOS_AMD64"]
     end
   end
-
+  
   $endorctl_file = "endorctl_#{version}_macos_#{use_arch}"
-  $download_url = "https://api.endorlabs.com/download/endorlabs/#{version}/binaries/#{$endorctl_file}"
-
-  # Download and install
-  url "https://api.endorlabs.com/meta/version", :using => EndorDownloadStrategy
+  $download_url = "https://api.endorlabs.com/download/endorlabs/#{version}/binaries/#{$endorctl_file}" 
+  
+  # Download properties
+  url $download_url
   sha256 $download_sha
-
+  
   def install
      bin.install "#{$endorctl_file}" => "endorctl"
   end

--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # Endorctl Homebrew Tap
+
 This repository contains a collection of Homebrew (aka, Brew) "formulae" for Endorctl
 
 ## Tap Endor Labs' repository
 
 ```sh
-$ brew tap endorlabs/tap
+brew tap endorlabs/tap
 ```
 
 ## Installing Endorctl
 
 ```sh
-$ brew install endorctl
+brew install endorctl
+```
+
+## Upgrading Endorctl
+
+```sh
+brew upgrade endorctl
 ```


### PR DESCRIPTION
Update from a fixed 'latest' version to tracking discrete versions, and add a livecheck block to support the command `brew upgrade endorctl`

[[BUG-654](https://endorlabs.atlassian.net/browse/BUG-654)]

[BUG-654]: https://endorlabs.atlassian.net/browse/BUG-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ